### PR TITLE
feat: add accounts listing page

### DIFF
--- a/envfile
+++ b/envfile
@@ -1,0 +1,1 @@
+EXPO_PUBLIC_API_BASE_URL=https://apimobile.saralaccount.com

--- a/src/BottomBar/Accounts.tsx
+++ b/src/BottomBar/Accounts.tsx
@@ -1,0 +1,147 @@
+import React, { useEffect, useState } from 'react';
+import { FlatList, StyleSheet, Text, TextInput, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { LinearGradient } from 'expo-linear-gradient';
+import Feather from '@react-native-vector-icons/feather';
+import axiosInstance from '../config/axios';
+import COLORS from '../../constants/color';
+
+interface Account {
+  accountId: number;
+  shortCode: string;
+  name: string;
+  openingBalance: number;
+  drcr: string;
+}
+
+export default function Accounts() {
+  const [accounts, setAccounts] = useState<Account[]>([]);
+  const [searchQuery, setSearchQuery] = useState('');
+
+  useEffect(() => {
+    const fetchAccounts = async () => {
+      try {
+        const res = await axiosInstance.get('/api/AccountMaster/list', { params: { accountid: 0 } });
+        if (res.data.success) {
+          setAccounts(res.data.data);
+        }
+      } catch (e) {
+        console.warn(e);
+      }
+    };
+
+    fetchAccounts();
+  }, []);
+
+  const filteredAccounts = accounts.filter((account) =>
+    account.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+    account.shortCode.toLowerCase().includes(searchQuery.toLowerCase())
+  );
+
+  const formatCurrency = (amount: number) => {
+    return new Intl.NumberFormat('en-IN', {
+      style: 'currency',
+      currency: 'INR',
+      minimumFractionDigits: 2,
+    }).format(Math.abs(amount));
+  };
+
+  const renderItem = ({ item }: { item: Account }) => (
+    <View style={styles.itemContainer}>
+      <View>
+        <Text style={styles.shortCode}>{item.shortCode}</Text>
+        <Text style={styles.name}>{item.name}</Text>
+      </View>
+      <View style={styles.balanceContainer}>
+        <Text style={styles.balance}>{formatCurrency(item.openingBalance)}</Text>
+        <Feather
+          name={item.drcr.toLowerCase() === 'dr' ? 'arrow-down-right' : 'arrow-up-right'}
+          size={16}
+          color={item.drcr.toLowerCase() === 'dr' ? COLORS.red : COLORS.success}
+        />
+      </View>
+    </View>
+  );
+
+  return (
+    <SafeAreaView style={styles.container} edges={['top']}>
+      <LinearGradient
+        colors={['#ec7d20', '#be2b2c']}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 0, y: 1 }}
+        style={styles.header}
+      >
+        <Text style={styles.headerTitle}>Accounts</Text>
+      </LinearGradient>
+      <View style={styles.searchContainer}>
+        <TextInput
+          placeholder="Search"
+          value={searchQuery}
+          onChangeText={setSearchQuery}
+          style={styles.search}
+        />
+      </View>
+      <FlatList
+        data={filteredAccounts}
+        keyExtractor={(item) => item.accountId.toString()}
+        renderItem={renderItem}
+        contentContainerStyle={{ paddingBottom: 20 }}
+      />
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: COLORS.white,
+  },
+  header: {
+    paddingTop: 20,
+    paddingBottom: 20,
+  },
+  headerTitle: {
+    color: COLORS.white,
+    fontSize: 20,
+    fontWeight: '500',
+    textAlign: 'center',
+  },
+  searchContainer: {
+    padding: 12,
+  },
+  search: {
+    borderWidth: 1,
+    borderColor: '#e1e1e1',
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    height: 40,
+  },
+  itemContainer: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: 12,
+    paddingVertical: 16,
+    borderBottomWidth: 1,
+    borderBottomColor: '#f1f1f1',
+  },
+  shortCode: {
+    color: COLORS.lightGrey,
+    fontSize: 13,
+  },
+  name: {
+    color: COLORS.black,
+    fontSize: 15,
+    fontWeight: '600',
+    paddingTop: 4,
+  },
+  balanceContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  balance: {
+    color: COLORS.black,
+    fontSize: 13,
+    marginRight: 8,
+  },
+});

--- a/src/Navigation/Tab.tsx
+++ b/src/Navigation/Tab.tsx
@@ -5,14 +5,11 @@ import AccountMaster from '../BottomBar/accountMaster'
 import VoucherEntry from '../BottomBar/voucherEntry'
 import GeneralLedger from '../BottomBar/generalLedger'
 import TrailBalance from '../BottomBar/TrailBalance'
+import Accounts from '../BottomBar/Accounts'
 import { LinearGradient } from 'expo-linear-gradient'
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs'
 
-
 const Tab = createBottomTabNavigator();
-
-
-
 
 function TabNavigator() {
   return (
@@ -88,7 +85,6 @@ function TabNavigator() {
               <View>
                 <Image source={DASHBOARD_WHITE} style={styles.menuIcon} />
               </View>
-              {/* <Text>Dashboard</Text> */}
             </LinearGradient>
           )
         }}
@@ -123,13 +119,26 @@ function TabNavigator() {
           )
         }}
       />
+      <Tab.Screen
+        name="Calc"
+        component={Accounts}
+        options={{
+          headerShown: false,
+          tabBarIcon: ({ color, focused }) => (
+            <Image source={focused ? ACCOUNTMASTER : ACCOUNTMASTER_GREY} style={styles.menuIcon} />
+          ),
+          tabBarLabel: ({ focused, color }) => (
+            <Text style={{ color: focused ? '#cd4a26' : '#979797', fontSize: focused ? 11 : 10, marginTop: 4 }}>
+              Calc.
+            </Text>
+          )
+        }}
+      />
     </Tab.Navigator>
   )
 }
 
-
 export default TabNavigator
-
 
 const styles = StyleSheet.create({
   container: {
@@ -142,4 +151,4 @@ const styles = StyleSheet.create({
     width: 30,
     height: 30
   }
-});
+})

--- a/src/config/axios.js
+++ b/src/config/axios.js
@@ -1,7 +1,7 @@
 import axios from "axios";
 
 const axiosInstance = axios.create({
-    baseURL: 'https://apimobile.saralaccount.com'
-})
+  baseURL: process.env.EXPO_PUBLIC_API_BASE_URL || 'https://apimobile.saralaccount.com',
+});
 
-export default axiosInstance
+export default axiosInstance;


### PR DESCRIPTION
## Summary
- set API base URL in envfile and consume it in axios config
- add Accounts screen with search and colored DR/CR arrows
- wire Accounts page to new Calc tab in bottom navigation

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_688dc893c24c8330a6953c1a527c8198